### PR TITLE
iterate over players if they're in vehicles instead of all the entities if they're vehicles

### DIFF
--- a/lua/autorun/hl2hud/elements/vehicle.lua
+++ b/lua/autorun/hl2hud/elements/vehicle.lua
@@ -16,10 +16,10 @@ if SERVER then
 
   -- [[ Update player driven vehicles weapon status ]] --
   hook.Add('Tick', HL2HUD.hookname, function()
-    for _, ply in pairs(player.GetAll()) do
+    for _, ply in pairs(player.GetAll()) do -- we only ever see it for the players, so we will only do it for players
       if not IsValid(ply) or not ply:InVehicle() or not IsValid(ply:GetVehicle()) then continue end
       local vehicle = ply:GetVehicle()
-      if not vehicle:IsVehicle() or not IsValid(vehicle:GetDriver()) or vehicle:GetDriver() != ply or not vehicle:GetInternalVariable(NWVAR_ENABLE) then continue end
+      if not IsValid(vehicle) or not vehicle:IsVehicle() or not IsValid(vehicle:GetDriver()) or not vehicle:GetDriver():IsPlayer() or not vehicle:GetInternalVariable(NWVAR_ENABLE) then continue end -- secondary old checks, will still be a magnitude more performant
       vehicle:SetNWBool(NWVAR_FIRE, vehicle:GetInternalVariable(NWVAR_FIRE))
       net.Start(NET)
       net.WriteVector(vehicle:GetInternalVariable(NWVAR_CROSSHAIR) - vehicle:GetPos())

--- a/lua/autorun/hl2hud/elements/vehicle.lua
+++ b/lua/autorun/hl2hud/elements/vehicle.lua
@@ -16,7 +16,9 @@ if SERVER then
 
   -- [[ Update vehicles weapon status ]] --
   hook.Add('Tick', HL2HUD.hookname, function()
-    for _, vehicle in pairs(ents.GetAll()) do
+    for _, ply in pairs(player.GetAll()) do
+      if not ply:InVehicle() then continue end
+      local vehicle = ply:GetVehicle()
       if not vehicle:IsVehicle() or not IsValid(vehicle:GetDriver()) or not vehicle:GetDriver():IsPlayer() or not vehicle:GetInternalVariable(NWVAR_ENABLE) then continue end
       vehicle:SetNWBool(NWVAR_FIRE, vehicle:GetInternalVariable(NWVAR_FIRE))
       net.Start(NET)


### PR DESCRIPTION
should notably reduce server realm overhead